### PR TITLE
Add route params to route history

### DIFF
--- a/addon/services/route-history.js
+++ b/addon/services/route-history.js
@@ -60,11 +60,11 @@ export default Ember.Service.extend({
 	 * @param routeName
 	 * @return The current history stack.
 	 */
-	addRouteToHistory(routeName) {
+	addRouteToHistory(routeName, params) {
 		const maxHistoryLength = this.get('maxHistoryLength');
 		let history = this.get('history');
 
-		history.pushObject(routeName);
+		history.pushObject([routeName, params]);
 
 		if (history.get('length') > maxHistoryLength) {
 			history.shiftObject();
@@ -80,8 +80,8 @@ export default Ember.Service.extend({
 	setCurrentRoute(route) {
 		const routeName = route.get('routeName');
 		if (routeName !== 'loading') {
-			this.set('current', routeName);
-			this.addRouteToHistory(routeName);
+			this.set('current', [routeName, route.paramsFor(routeName)]);
+			this.addRouteToHistory(routeName, route.paramsFor(routeName));
 		}
 	}
 });


### PR DESCRIPTION
I needed this feature for a project that I am working on. I'm not sure if this implementation is in-line with your goals for this add-on, so I will leave this for you to review. Let me know what you think. The goal of this was to provide the route params as part of the history. Now I can do something like this:

``` js
var previousRoute = this.get('routeHistory.previous');
var routeName = previousRoute[0];
var routeParams = previousRoute[1];
if (routeName == 'post') {
  this.transitionToRoute('post', routeParams.post_id);
}
```
